### PR TITLE
Add Gravity Forms visual product configurator field plugin

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,134 @@
+.gf-vpc-setting-section {
+margin: 1em 0;
+padding: 1em;
+background: #fff;
+border: 1px solid #ccd0d4;
+border-radius: 4px;
+}
+
+.gf-vpc-setting-section h4 {
+margin-top: 0;
+}
+
+.gf-vpc-field-grid {
+display: grid;
+grid-template-columns: 150px 1fr;
+grid-gap: 0.5em 1em;
+align-items: center;
+}
+
+.gf-vpc-field-grid input[type="number"],
+.gf-vpc-field-grid input[type="text"] {
+width: 100%;
+}
+
+.gf-vpc-media-control {
+display: flex;
+gap: 0.5em;
+align-items: center;
+}
+
+.gf-vpc-media-control input[type="text"] {
+flex: 1;
+}
+
+.gf-vpc-layers {
+margin: 1em 0;
+padding: 0;
+list-style: none;
+}
+
+.gf-vpc-layer {
+margin-bottom: 1em;
+border: 1px solid #dcdcdc;
+border-radius: 4px;
+background: #f9f9f9;
+}
+
+.gf-vpc-layer-header {
+display: flex;
+justify-content: space-between;
+align-items: center;
+padding: 0.75em 1em;
+border-bottom: 1px solid #dcdcdc;
+background: #fff;
+}
+
+.gf-vpc-layer-actions {
+display: flex;
+gap: 0.5em;
+align-items: center;
+}
+
+.gf-vpc-layer-body {
+padding: 1em;
+display: grid;
+grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+gap: 1em;
+}
+
+.gf-vpc-layer-body label span,
+.gf-vpc-layer-position legend {
+font-weight: 600;
+display: block;
+margin-bottom: 0.25em;
+}
+
+.gf-vpc-layer-body input[type="text"],
+.gf-vpc-layer-body select {
+width: 100%;
+}
+
+.gf-vpc-layer-position {
+grid-column: 1 / -1;
+display: grid;
+grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+gap: 1em;
+margin: 0;
+padding: 0.5em;
+border: 1px solid #dcdcdc;
+background: #fff;
+}
+
+.gf-vpc-layer-conditional {
+grid-column: 1 / -1;
+display: flex;
+align-items: center;
+gap: 0.5em;
+}
+
+.gf-vpc-layer-overlay,
+.gf-vpc-layer-choice-mapping {
+grid-column: 1 / -1;
+}
+
+.gf-vpc-choice-list {
+margin: 0.5em 0 0;
+padding: 0;
+list-style: none;
+display: grid;
+gap: 0.5em;
+}
+
+.gf-vpc-choice {
+border: 1px solid #dcdcdc;
+border-radius: 4px;
+padding: 0.75em;
+background: #fff;
+}
+
+.gf-vpc-choice-fields {
+display: grid;
+grid-template-columns: 1fr;
+gap: 0.5em;
+}
+
+.gf-vpc-choice .gf-vpc-media-control {
+flex-direction: row;
+}
+
+.gf-vpc-layer-placeholder {
+height: 60px;
+border: 2px dashed #0073aa;
+margin-bottom: 1em;
+}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,29 @@
+.gf-visual-configurator-field {
+margin: 1.5em 0;
+}
+
+.gf-visual-configurator {
+position: relative;
+display: flex;
+flex-direction: column;
+gap: 1em;
+}
+
+.gf-vpc-canvas {
+width: 100%;
+height: auto;
+border: 1px solid #e2e2e2;
+background: #ffffff;
+box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
+.gf-vpc-control-container {
+display: none;
+}
+
+.gf-vpc-entry-image {
+max-width: 100%;
+height: auto;
+border: 1px solid #e2e2e2;
+border-radius: 4px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,489 @@
+(function( $ ) {
+'use strict';
+
+const GFVPCAdmin = {
+field: null,
+config: null,
+defaults: {},
+$settings: null,
+$layerList: null,
+layerTemplate: '',
+choiceTemplate: '',
+
+init() {
+this.$settings      = $( '.visual_configurator_setting' );
+this.$layerList     = this.$settings.find( '.gf-vpc-layers' );
+this.layerTemplate  = $( '#gf-vpc-layer-template' ).html();
+this.choiceTemplate = $( '#gf-vpc-choice-template' ).html();
+
+$( document ).on( 'gform_load_field_settings', ( event, field ) => {
+this.onFieldSettingsLoad( field );
+} );
+
+this.bindEvents();
+},
+
+bindEvents() {
+$( document ).on( 'input change', '#gf-vpc-canvas-width', ( event ) => {
+if ( ! this.config ) {
+return;
+}
+
+const value = parseInt( event.target.value, 10 );
+this.config.canvas.width = Number.isNaN( value ) ? '' : value;
+this.persist();
+} );
+
+$( document ).on( 'input change', '#gf-vpc-canvas-height', ( event ) => {
+if ( ! this.config ) {
+return;
+}
+
+const value = parseInt( event.target.value, 10 );
+this.config.canvas.height = Number.isNaN( value ) ? '' : value;
+this.persist();
+} );
+
+$( document ).on( 'click', '.gf-vpc-select-media', ( event ) => {
+event.preventDefault();
+this.handleMediaSelect( $( event.currentTarget ) );
+} );
+
+$( document ).on( 'click', '.gf-vpc-clear-media', ( event ) => {
+event.preventDefault();
+this.handleMediaClear( $( event.currentTarget ) );
+} );
+
+$( document ).on( 'click', '.gf-vpc-add-layer', ( event ) => {
+event.preventDefault();
+this.addLayer();
+} );
+
+$( document ).on( 'click', '.gf-vpc-remove-layer', ( event ) => {
+event.preventDefault();
+const $layer = $( event.currentTarget ).closest( '.gf-vpc-layer' );
+this.removeLayer( $layer.data( 'layerId' ) );
+} );
+
+$( document ).on( 'input', '.gf-vpc-layer-name', ( event ) => {
+const $layer = $( event.currentTarget ).closest( '.gf-vpc-layer' );
+const layer  = this.getLayer( $layer.data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+layer.name = event.currentTarget.value;
+this.updateLayerHeader( $layer, layer );
+this.persist();
+} );
+
+$( document ).on( 'change', '.gf-vpc-layer-type', ( event ) => {
+const $layer = $( event.currentTarget ).closest( '.gf-vpc-layer' );
+const layer  = this.getLayer( $layer.data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+layer.type = event.currentTarget.value;
+this.updateLayerVisibility( $layer, layer );
+this.updateLayerHeader( $layer, layer );
+this.persist();
+} );
+
+$( document ).on( 'input', '.gf-vpc-layer-control', ( event ) => {
+const layer = this.getLayer( $( event.currentTarget ).closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+layer.controlFieldId = event.currentTarget.value;
+this.persist();
+} );
+
+$( document ).on( 'input', '.gf-vpc-layer-pos', ( event ) => {
+const $input = $( event.currentTarget );
+const layer  = this.getLayer( $input.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+const axis = $input.data( 'axis' );
+if ( ! layer.position ) {
+layer.position = { x: '0', y: '0', width: '100', height: '100' };
+}
+layer.position[ axis ] = $input.val();
+this.persist();
+} );
+
+$( document ).on( 'change', '.gf-vpc-layer-conditional-toggle', ( event ) => {
+const layer = this.getLayer( $( event.currentTarget ).closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+layer.conditionalLogic = event.currentTarget.checked;
+this.persist();
+} );
+
+$( document ).on( 'click', '.gf-vpc-add-choice', ( event ) => {
+event.preventDefault();
+const $layer = $( event.currentTarget ).closest( '.gf-vpc-layer' );
+this.addChoice( $layer.data( 'layerId' ) );
+} );
+
+$( document ).on( 'click', '.gf-vpc-remove-choice', ( event ) => {
+event.preventDefault();
+const $choice = $( event.currentTarget ).closest( '.gf-vpc-choice' );
+this.removeChoice( $choice );
+} );
+
+$( document ).on( 'input', '.gf-vpc-choice-value', ( event ) => {
+const $choice = $( event.currentTarget ).closest( '.gf-vpc-choice' );
+const layer   = this.getLayer( $choice.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+const choice = this.getChoice( layer, $choice.data( 'choiceId' ) );
+if ( ! choice ) {
+return;
+}
+
+choice.value = event.currentTarget.value;
+this.persist();
+} );
+},
+
+onFieldSettingsLoad( field ) {
+if ( 'visual_configurator' !== field.type ) {
+this.$settings.hide();
+this.field  = null;
+this.config = null;
+return;
+}
+
+this.field  = field;
+const defaults = this.defaults && Object.keys( this.defaults ).length ? this.defaults : {};
+this.config = this.cloneConfig( field.visual_configurator_settings || defaults );
+
+if ( ! this.config.canvas ) {
+this.config.canvas = { width: 600, height: 600, baseImage: { id: 0, url: '' } };
+}
+
+if ( ! Array.isArray( this.config.layers ) ) {
+this.config.layers = [];
+}
+
+this.ensureIdentifiers();
+this.render();
+
+this.$settings.show();
+
+if ( this.$layerList.data( 'ui-sortable' ) ) {
+this.$layerList.sortable( 'destroy' );
+}
+
+this.$layerList.sortable( {
+handle: '.dashicons-move',
+placeholder: 'gf-vpc-layer-placeholder',
+update: () => {
+this.syncOrderFromDom();
+}
+} );
+},
+
+render() {
+$( '#gf-vpc-canvas-width' ).val( this.config.canvas.width || '' );
+$( '#gf-vpc-canvas-height' ).val( this.config.canvas.height || '' );
+$( '#gf-vpc-base-image' ).val( this.config.canvas.baseImage ? this.config.canvas.baseImage.url : '' );
+
+this.$layerList.empty();
+
+this.config.layers.forEach( ( layer ) => {
+this.$layerList.append( this.createLayerElement( layer ) );
+} );
+
+this.persist();
+},
+
+createLayerElement( layer ) {
+const $layer = $( this.layerTemplate );
+$layer.attr( 'data-layer-id', layer.uid );
+
+$layer.find( '.gf-vpc-layer-name' ).val( layer.name || '' );
+$layer.find( '.gf-vpc-layer-type' ).val( layer.type || 'color_fill' );
+$layer.find( '.gf-vpc-layer-control' ).val( layer.controlFieldId || '' );
+
+if ( ! layer.position ) {
+layer.position = { x: '0', y: '0', width: '100', height: '100' };
+}
+
+$layer.find( '.gf-vpc-layer-pos[data-axis="x"]' ).val( layer.position.x || '' );
+$layer.find( '.gf-vpc-layer-pos[data-axis="y"]' ).val( layer.position.y || '' );
+$layer.find( '.gf-vpc-layer-pos[data-axis="width"]' ).val( layer.position.width || '' );
+$layer.find( '.gf-vpc-layer-pos[data-axis="height"]' ).val( layer.position.height || '' );
+
+$layer.find( '.gf-vpc-layer-conditional-toggle' ).prop( 'checked', !! layer.conditionalLogic );
+
+const overlayUrl = layer.overlayImage && layer.overlayImage.url ? layer.overlayImage.url : '';
+$layer.find( '.gf-vpc-layer-overlay-url' ).val( overlayUrl );
+
+const $choiceList = $layer.find( '.gf-vpc-choice-list' );
+$choiceList.empty();
+if ( ! Array.isArray( layer.choiceMapping ) ) {
+layer.choiceMapping = [];
+}
+
+layer.choiceMapping.forEach( ( choice ) => {
+$choiceList.append( this.createChoiceElement( choice ) );
+} );
+
+this.updateLayerVisibility( $layer, layer );
+this.updateLayerHeader( $layer, layer );
+
+return $layer;
+},
+
+createChoiceElement( choice ) {
+const $choice = $( this.choiceTemplate );
+$choice.attr( 'data-choice-id', choice.uid );
+$choice.find( '.gf-vpc-choice-value' ).val( choice.value || '' );
+$choice.find( '.gf-vpc-choice-image' ).val( choice.image && choice.image.url ? choice.image.url : '' );
+
+return $choice;
+},
+
+addLayer() {
+if ( ! this.config ) {
+return;
+}
+
+const layer = {
+uid: this.generateUid( 'layer' ),
+name: '',
+type: 'color_fill',
+controlFieldId: '',
+position: { x: '0', y: '0', width: '100', height: '100' },
+conditionalLogic: false,
+overlayImage: { id: 0, url: '' },
+choiceMapping: [],
+};
+
+this.config.layers.push( layer );
+this.$layerList.append( this.createLayerElement( layer ) );
+this.persist();
+},
+
+removeLayer( layerId ) {
+if ( ! this.config ) {
+return;
+}
+
+this.config.layers = this.config.layers.filter( ( layer ) => layer.uid !== layerId );
+this.$layerList.find( `.gf-vpc-layer[data-layer-id="${ layerId }"]` ).remove();
+this.persist();
+},
+
+addChoice( layerId ) {
+const layer = this.getLayer( layerId );
+if ( ! layer ) {
+return;
+}
+
+const choice = {
+uid: this.generateUid( 'choice' ),
+value: '',
+image: { id: 0, url: '' },
+};
+
+layer.choiceMapping.push( choice );
+const $layer = this.$layerList.find( `.gf-vpc-layer[data-layer-id="${ layerId }"]` );
+$layer.find( '.gf-vpc-choice-list' ).append( this.createChoiceElement( choice ) );
+this.persist();
+},
+
+removeChoice( $choice ) {
+const $layer = $choice.closest( '.gf-vpc-layer' );
+const layer  = this.getLayer( $layer.data( 'layerId' ) );
+if ( ! layer ) {
+return;
+}
+
+layer.choiceMapping = layer.choiceMapping.filter( ( choice ) => choice.uid !== $choice.data( 'choiceId' ) );
+$choice.remove();
+this.persist();
+},
+
+handleMediaSelect( $button ) {
+const target = $button.data( 'target' );
+if ( ! target ) {
+return;
+}
+
+const frame = wp.media( {
+title: $button.data( 'title' ) || 'Select Image',
+button: {
+text: $button.data( 'button' ) || 'Use image',
+},
+multiple: false,
+} );
+
+frame.on( 'select', () => {
+const attachment = frame.state().get( 'selection' ).first().toJSON();
+this.assignMedia( $button, target, attachment );
+} );
+
+frame.open();
+},
+
+handleMediaClear( $button ) {
+const target = $button.data( 'target' );
+const $wrapper = $button.closest( '.gf-vpc-media-control' );
+$wrapper.find( 'input[type="text"]' ).val( '' );
+
+if ( 'baseImage' === target && this.config ) {
+this.config.canvas.baseImage = { id: 0, url: '' };
+} else if ( 'overlayImage' === target ) {
+const layer = this.getLayer( $button.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( layer ) {
+layer.overlayImage = { id: 0, url: '' };
+}
+} else if ( 'choiceImage' === target ) {
+const $choice = $button.closest( '.gf-vpc-choice' );
+const layer   = this.getLayer( $choice.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( layer ) {
+const choice = this.getChoice( layer, $choice.data( 'choiceId' ) );
+if ( choice ) {
+choice.image = { id: 0, url: '' };
+}
+}
+}
+
+this.persist();
+},
+
+assignMedia( $button, target, attachment ) {
+const data = { id: attachment.id, url: attachment.url };
+const $wrapper = $button.closest( '.gf-vpc-media-control' );
+$wrapper.find( 'input[type="text"]' ).val( attachment.url );
+
+if ( 'baseImage' === target && this.config ) {
+this.config.canvas.baseImage = data;
+} else if ( 'overlayImage' === target ) {
+const layer = this.getLayer( $button.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( layer ) {
+layer.overlayImage = data;
+}
+} else if ( 'choiceImage' === target ) {
+const $choice = $button.closest( '.gf-vpc-choice' );
+const layer   = this.getLayer( $choice.closest( '.gf-vpc-layer' ).data( 'layerId' ) );
+if ( layer ) {
+const choice = this.getChoice( layer, $choice.data( 'choiceId' ) );
+if ( choice ) {
+choice.image = data;
+}
+}
+}
+
+this.persist();
+},
+
+updateLayerHeader( $layer, layer ) {
+const title = layer.name ? `${ layer.name }` : 'Layer';
+const type  = layer.type ? layer.type.replace( /_/g, ' ' ) : '';
+$layer.find( '.gf-vpc-layer-title' ).text( `${ title }${ type ? ' · ' + type : '' }` );
+},
+
+updateLayerVisibility( $layer, layer ) {
+const type = layer.type || 'color_fill';
+$layer.find( '.gf-vpc-layer-overlay' ).toggle( 'image_overlay' === type );
+$layer.find( '.gf-vpc-layer-choice-mapping' ).toggle( 'image_choice' === type );
+},
+
+syncOrderFromDom() {
+const order = [];
+this.$layerList.find( '.gf-vpc-layer' ).each( ( index, element ) => {
+order.push( $( element ).data( 'layerId' ) );
+} );
+
+const layers = [];
+order.forEach( ( id ) => {
+const layer = this.getLayer( id );
+if ( layer ) {
+layers.push( layer );
+}
+} );
+
+this.config.layers = layers;
+this.persist();
+},
+
+getLayer( layerId ) {
+if ( ! this.config || ! Array.isArray( this.config.layers ) ) {
+return null;
+}
+
+return this.config.layers.find( ( layer ) => layer.uid === layerId ) || null;
+},
+
+getChoice( layer, choiceId ) {
+if ( ! layer || ! Array.isArray( layer.choiceMapping ) ) {
+return null;
+}
+
+return layer.choiceMapping.find( ( choice ) => choice.uid === choiceId ) || null;
+},
+
+persist() {
+if ( ! this.field || ! this.config ) {
+return;
+}
+
+this.field.visual_configurator_settings = this.cloneConfig( this.config );
+if ( 'function' === typeof SetFieldProperty ) {
+SetFieldProperty( 'visual_configurator_settings', this.cloneConfig( this.config ) );
+}
+$( '#visual_configurator_settings' ).val( JSON.stringify( this.config ) );
+},
+
+ensureIdentifiers() {
+this.config.layers.forEach( ( layer ) => {
+if ( ! layer.uid ) {
+layer.uid = this.generateUid( 'layer' );
+}
+if ( ! layer.position ) {
+layer.position = { x: '0', y: '0', width: '100', height: '100' };
+}
+if ( ! Array.isArray( layer.choiceMapping ) ) {
+layer.choiceMapping = [];
+}
+layer.choiceMapping.forEach( ( choice ) => {
+if ( ! choice.uid ) {
+choice.uid = this.generateUid( 'choice' );
+}
+if ( ! choice.image ) {
+choice.image = { id: 0, url: '' };
+}
+} );
+} );
+},
+
+generateUid( prefix ) {
+return `${ prefix }_${ Math.random().toString( 36 ).substr( 2, 9 ) }`;
+},
+
+cloneConfig( source ) {
+if ( ! source ) {
+return {};
+}
+
+return JSON.parse( JSON.stringify( source ) );
+},
+};
+
+$( () => {
+GFVPCAdmin.defaults = window.GFVisualConfiguratorDefaults || {};
+GFVPCAdmin.init();
+} );
+
+})( jQuery );

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,416 @@
+(function() {
+'use strict';
+
+function parseJSON( value ) {
+try {
+return JSON.parse( value );
+} catch ( error ) {
+console.error( 'GF Visual Configurator: Unable to parse configuration.', error );
+return null;
+}
+}
+
+function clone( source ) {
+return JSON.parse( JSON.stringify( source || {} ) );
+}
+
+class VisualConfigurator {
+constructor( element ) {
+this.element      = element;
+this.canvas       = element.querySelector( '.gf-vpc-canvas' );
+this.context      = this.canvas ? this.canvas.getContext( '2d' ) : null;
+this.hiddenInput  = element.querySelector( '.gf-vpc-result' );
+this.formId       = parseInt( element.getAttribute( 'data-form-id' ), 10 );
+this.fieldId      = parseInt( element.getAttribute( 'data-field-id' ), 10 );
+this.form         = element.closest( 'form' );
+this.imageCache   = new Map();
+this.layerStates  = new Map();
+this.drawScheduled = false;
+}
+
+init() {
+if ( ! this.canvas || ! this.context ) {
+return;
+}
+
+const configValue = this.element.getAttribute( 'data-config' );
+const config      = configValue ? parseJSON( configValue ) : null;
+
+if ( ! config ) {
+return;
+}
+
+this.config = clone( config );
+this.prepareLayers();
+this.bindLayerControls();
+this.redrawCanvas();
+this.bindFormSubmit();
+}
+
+prepareLayers() {
+if ( ! this.config.canvas ) {
+this.config.canvas = { width: this.canvas.width, height: this.canvas.height, baseImage: { url: '' } };
+}
+
+if ( this.config.canvas.width ) {
+this.canvas.width = parseInt( this.config.canvas.width, 10 );
+}
+
+if ( this.config.canvas.height ) {
+this.canvas.height = parseInt( this.config.canvas.height, 10 );
+}
+
+if ( ! Array.isArray( this.config.layers ) ) {
+this.config.layers = [];
+}
+
+this.config.layers.forEach( ( layer, index ) => {
+if ( ! layer.uid ) {
+layer.uid = 'layer_' + ( index + 1 );
+}
+
+if ( ! layer.position ) {
+layer.position = { x: '0', y: '0', width: '100', height: '100' };
+}
+} );
+}
+
+bindLayerControls() {
+this.config.layers.forEach( ( layer ) => {
+const controls = this.findControls( layer.controlFieldId );
+const state    = this.getLayerState( layer );
+
+state.controls = controls;
+
+controls.forEach( ( control ) => {
+const handler = ( event ) => {
+if ( control.type && 'file' === control.type.toLowerCase() ) {
+this.handleFileControl( layer, control );
+} else {
+this.scheduleRedraw();
+}
+};
+
+control.addEventListener( 'change', handler );
+if ( control.tagName === 'INPUT' ) {
+control.addEventListener( 'input', handler );
+}
+} );
+} );
+}
+
+bindFormSubmit() {
+if ( ! this.form ) {
+return;
+}
+
+this.form.addEventListener( 'submit', () => {
+this.updateResultField();
+} );
+}
+
+findControls( controlFieldId ) {
+if ( ! controlFieldId || ! this.form ) {
+return [];
+}
+
+const controls = new Set();
+const nameSelectors = [ `input_${ controlFieldId }`, `input_${ controlFieldId }[]` ];
+
+nameSelectors.forEach( ( name ) => {
+const matches = this.form.querySelectorAll( `[name="${ name }"]` );
+matches.forEach( ( element ) => {
+if ( element.type && element.type.toLowerCase() === 'hidden' ) {
+return;
+}
+controls.add( element );
+} );
+} );
+
+const fieldWrapperId = `field_${ this.formId }_${ controlFieldId }`;
+const fieldWrapper   = document.getElementById( fieldWrapperId );
+
+if ( fieldWrapper ) {
+fieldWrapper.querySelectorAll( 'input, select, textarea' ).forEach( ( element ) => {
+if ( element.type && element.type.toLowerCase() === 'hidden' ) {
+return;
+}
+controls.add( element );
+} );
+}
+
+return Array.from( controls );
+}
+
+getLayerState( layer ) {
+const key = layer.uid || layer.controlFieldId || Math.random().toString( 36 ).slice( 2 );
+if ( ! this.layerStates.has( key ) ) {
+this.layerStates.set( key, { uploadData: '' } );
+}
+
+return this.layerStates.get( key );
+}
+
+scheduleRedraw() {
+if ( this.drawScheduled ) {
+return;
+}
+
+this.drawScheduled = true;
+window.requestAnimationFrame( () => {
+this.drawScheduled = false;
+this.redrawCanvas();
+} );
+}
+
+handleFileControl( layer, control ) {
+const files = control.files;
+if ( ! files || ! files.length ) {
+const state = this.getLayerState( layer );
+state.uploadData = '';
+this.scheduleRedraw();
+return;
+}
+
+const reader = new FileReader();
+reader.onload = () => {
+const state = this.getLayerState( layer );
+state.uploadData = reader.result;
+this.scheduleRedraw();
+};
+reader.readAsDataURL( files[0] );
+}
+
+async redrawCanvas() {
+if ( ! this.context ) {
+return;
+}
+
+const width  = this.canvas.width;
+const height = this.canvas.height;
+
+this.context.clearRect( 0, 0, width, height );
+
+const baseImageUrl = this.getBaseImageUrl();
+if ( baseImageUrl ) {
+await this.drawImage( baseImageUrl, { x: 0, y: 0, width, height } );
+}
+
+for ( const layer of this.config.layers ) {
+await this.drawLayer( layer );
+}
+
+this.updateResultField();
+}
+
+getBaseImageUrl() {
+if ( ! this.config || ! this.config.canvas || this.config.canvas.baseImage === undefined ) {
+return '';
+}
+
+const baseImage = this.config.canvas.baseImage;
+if ( typeof baseImage === 'string' ) {
+return baseImage;
+}
+
+return baseImage && baseImage.url ? baseImage.url : '';
+}
+
+async drawLayer( layer ) {
+const type = layer.type || 'color_fill';
+const rect = this.getLayerRect( layer );
+
+switch ( type ) {
+case 'color_fill':
+this.drawColorLayer( layer, rect );
+break;
+case 'image_upload':
+await this.drawUploadLayer( layer, rect );
+break;
+case 'image_choice':
+await this.drawChoiceLayer( layer, rect );
+break;
+case 'image_overlay':
+await this.drawOverlayLayer( layer, rect );
+break;
+default:
+break;
+}
+}
+
+drawColorLayer( layer, rect ) {
+const value = this.getControlValue( layer );
+if ( ! value ) {
+return;
+}
+
+this.context.save();
+this.context.fillStyle = value;
+this.context.fillRect( rect.x, rect.y, rect.width, rect.height );
+this.context.restore();
+}
+
+async drawUploadLayer( layer, rect ) {
+const state = this.getLayerState( layer );
+if ( ! state.uploadData ) {
+return;
+}
+
+await this.drawImage( state.uploadData, rect );
+}
+
+async drawChoiceLayer( layer, rect ) {
+const value = this.getControlValue( layer );
+if ( ! value ) {
+return;
+}
+
+const mappings = Array.isArray( layer.choiceMapping ) ? layer.choiceMapping : [];
+const match    = mappings.find( ( item ) => item.value === value );
+const imageUrl = match && match.image ? match.image.url : '';
+
+if ( imageUrl ) {
+await this.drawImage( imageUrl, rect );
+}
+}
+
+async drawOverlayLayer( layer, rect ) {
+const imageUrl = layer.overlayImage && layer.overlayImage.url ? layer.overlayImage.url : '';
+if ( imageUrl ) {
+await this.drawImage( imageUrl, rect );
+}
+}
+
+getControlValue( layer ) {
+const state = this.getLayerState( layer );
+const controls = state.controls || [];
+if ( ! controls.length ) {
+return '';
+}
+
+const primary = controls[0];
+if ( primary.type && primary.type.toLowerCase() === 'file' ) {
+return state.uploadData || '';
+}
+
+if ( primary.tagName === 'SELECT' ) {
+return primary.value;
+}
+
+if ( primary.type && primary.type.toLowerCase() === 'radio' ) {
+const checked = controls.find( ( control ) => control.checked );
+return checked ? checked.value : '';
+}
+
+return primary.value;
+}
+
+getLayerRect( layer ) {
+const position = layer.position || {};
+const width    = this.canvas.width;
+const height   = this.canvas.height;
+
+const parsePercent = ( value, fallback ) => {
+if ( value === undefined || value === null || value === '' ) {
+return fallback;
+}
+
+let numeric = value;
+if ( typeof numeric === 'string' ) {
+numeric = numeric.trim();
+if ( numeric.endsWith( '%' ) ) {
+numeric = numeric.slice( 0, -1 );
+}
+}
+
+numeric = parseFloat( numeric );
+return Number.isNaN( numeric ) ? fallback : numeric;
+};
+
+const xPercent      = parsePercent( position.x, 0 );
+const yPercent      = parsePercent( position.y, 0 );
+const widthPercent  = parsePercent( position.width, 100 );
+const heightPercent = parsePercent( position.height, 100 );
+
+return {
+x: ( xPercent / 100 ) * width,
+y: ( yPercent / 100 ) * height,
+width: ( widthPercent / 100 ) * width,
+height: ( heightPercent / 100 ) * height,
+};
+}
+
+async drawImage( src, rect ) {
+if ( ! src ) {
+return;
+}
+
+if ( rect.width <= 0 || rect.height <= 0 ) {
+return;
+}
+
+const image = await this.loadImage( src );
+if ( ! image ) {
+return;
+}
+
+this.context.drawImage( image, rect.x, rect.y, rect.width, rect.height );
+}
+
+loadImage( src ) {
+if ( this.imageCache.has( src ) ) {
+return this.imageCache.get( src );
+}
+
+const promise = new Promise( ( resolve, reject ) => {
+const image = new Image();
+image.crossOrigin = 'anonymous';
+image.onload = () => resolve( image );
+image.onerror = () => {
+console.warn( 'GF Visual Configurator: Unable to load image', src );
+resolve( null );
+};
+image.src = src;
+} );
+
+this.imageCache.set( src, promise );
+return promise;
+}
+
+updateResultField() {
+if ( ! this.hiddenInput ) {
+return;
+}
+
+try {
+const data = this.canvas.toDataURL( 'image/png' );
+this.hiddenInput.value = data;
+} catch ( error ) {
+console.error( 'GF Visual Configurator: Unable to export canvas.', error );
+}
+}
+}
+
+function initAll( root ) {
+const elements = root.querySelectorAll( '.gf-visual-configurator' );
+elements.forEach( ( element ) => {
+if ( element.dataset.vpcInitialized ) {
+return;
+}
+
+const instance = new VisualConfigurator( element );
+instance.init();
+element.dataset.vpcInitialized = '1';
+} );
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+initAll( document );
+} );
+
+if ( window.jQuery ) {
+window.jQuery( document ).on( 'gform_post_render', () => {
+initAll( document );
+} );
+}
+})();

--- a/gravity-forms-visual-product-configurator.php
+++ b/gravity-forms-visual-product-configurator.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Plugin Name:       Gravity Forms Visual Product Configurator
+ * Plugin URI:        https://example.com/
+ * Description:       Adds a powerful visual product configurator field type to Gravity Forms with a live canvas preview.
+ * Version:           0.1.0
+ * Author:            Your Name
+ * Author URI:        https://example.com/
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       gf-visual-product-configurator
+ * Domain Path:       /languages
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'GF_Visual_Product_Configurator_Plugin' ) ) {
+
+/**
+ * Main plugin bootstrap class.
+ */
+final class GF_Visual_Product_Configurator_Plugin {
+
+/**
+ * Plugin version.
+ *
+ * @var string
+ */
+public const VERSION = '0.1.0';
+
+/**
+ * Holds singleton instance.
+ *
+ * @var GF_Visual_Product_Configurator_Plugin|null
+ */
+private static $instance = null;
+
+/**
+ * Retrieve singleton instance.
+ *
+ * @return GF_Visual_Product_Configurator_Plugin
+ */
+public static function instance() {
+if ( null === self::$instance ) {
+self::$instance = new self();
+}
+
+return self::$instance;
+}
+
+/**
+ * Constructor.
+ */
+private function __construct() {
+$this->define_constants();
+
+add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+add_action( 'gform_loaded', array( $this, 'load_field_type' ), 5 );
+add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+add_action( 'gform_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ), 10, 2 );
+}
+
+/**
+ * Define core plugin constants.
+ */
+private function define_constants() {
+if ( ! defined( 'GF_VPC_VERSION' ) ) {
+define( 'GF_VPC_VERSION', self::VERSION );
+}
+
+if ( ! defined( 'GF_VPC_PLUGIN_FILE' ) ) {
+define( 'GF_VPC_PLUGIN_FILE', __FILE__ );
+}
+
+if ( ! defined( 'GF_VPC_PLUGIN_DIR' ) ) {
+define( 'GF_VPC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'GF_VPC_PLUGIN_URL' ) ) {
+define( 'GF_VPC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+}
+
+/**
+ * Load plugin textdomain.
+ */
+public function load_textdomain() {
+load_plugin_textdomain( 'gf-visual-product-configurator', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+
+/**
+ * Handle plugin activation.
+ */
+public static function activate() {
+// Placeholder for activation tasks.
+}
+
+/**
+ * Handle plugin deactivation.
+ */
+public static function deactivate() {
+// Placeholder for deactivation tasks.
+}
+
+/**
+ * Load the Visual Configurator field type when Gravity Forms is ready.
+ */
+public function load_field_type() {
+if ( ! class_exists( 'GFForms' ) ) {
+return;
+}
+
+require_once GF_VPC_PLUGIN_DIR . 'includes/class-gf-field-visual-configurator.php';
+
+GF_Visual_Product_Configurator_Field::register();
+}
+
+/**
+ * Enqueue assets for the Gravity Forms editor.
+ *
+ * @param string $hook Current admin page hook.
+ */
+public function enqueue_admin_assets( $hook ) {
+if ( false === strpos( $hook, 'gravityforms' ) ) {
+return;
+}
+
+wp_enqueue_media();
+
+if ( ! class_exists( 'GF_Visual_Product_Configurator_Field' ) ) {
+require_once GF_VPC_PLUGIN_DIR . 'includes/class-gf-field-visual-configurator.php';
+}
+
+wp_enqueue_style(
+'gf-vpc-admin',
+GF_VPC_PLUGIN_URL . 'assets/css/admin.css',
+array(),
+self::VERSION
+);
+
+wp_enqueue_script(
+'gf-vpc-admin',
+GF_VPC_PLUGIN_URL . 'assets/js/admin.js',
+array( 'jquery', 'gform_form_admin', 'jquery-ui-sortable' ),
+self::VERSION,
+true
+);
+
+wp_localize_script(
+'gf-vpc-admin',
+'GFVisualConfiguratorDefaults',
+GF_Visual_Product_Configurator_Field::get_default_settings()
+);
+}
+
+/**
+ * Enqueue frontend assets when a form contains a Visual Configurator field.
+ *
+ * @param array $form    Gravity Forms form object.
+ * @param bool  $is_ajax Whether the form uses AJAX.
+ */
+public function enqueue_frontend_assets( $form, $is_ajax ) {
+if ( ! $this->form_contains_configurator( $form ) ) {
+return;
+}
+
+wp_enqueue_style(
+'gf-vpc-frontend',
+GF_VPC_PLUGIN_URL . 'assets/css/frontend.css',
+array(),
+self::VERSION
+);
+
+wp_enqueue_script(
+'gf-vpc-frontend',
+GF_VPC_PLUGIN_URL . 'assets/js/frontend.js',
+array(),
+self::VERSION,
+true
+);
+}
+
+/**
+ * Determine if the provided form contains a Visual Configurator field.
+ *
+ * @param array $form Gravity Forms form array.
+ *
+ * @return bool
+ */
+private function form_contains_configurator( $form ) {
+if ( empty( $form['fields'] ) || ! is_array( $form['fields'] ) ) {
+return false;
+}
+
+foreach ( $form['fields'] as $field ) {
+if ( isset( $field->type ) && 'visual_configurator' === $field->type ) {
+return true;
+}
+}
+
+return false;
+}
+}
+}
+
+GF_Visual_Product_Configurator_Plugin::instance();
+
+register_activation_hook( __FILE__, array( 'GF_Visual_Product_Configurator_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'GF_Visual_Product_Configurator_Plugin', 'deactivate' ) );

--- a/includes/class-gf-field-visual-configurator.php
+++ b/includes/class-gf-field-visual-configurator.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * Gravity Forms Visual Configurator field definition.
+ *
+ * @package GFVisualProductConfigurator
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'GF_Visual_Product_Configurator_Field' ) ) {
+
+/**
+ * Visual Configurator field class.
+ */
+class GF_Visual_Product_Configurator_Field extends GF_Field {
+
+/**
+ * Field type name.
+ *
+ * @var string
+ */
+public $type = 'visual_configurator';
+
+/**
+ * Register hooks and field with Gravity Forms.
+ */
+public static function register() {
+GF_Fields::register( new self() );
+
+add_filter( 'gform_add_field_buttons', array( __CLASS__, 'add_form_editor_button' ) );
+add_filter( 'gform_tooltips', array( __CLASS__, 'register_tooltips' ) );
+add_action( 'gform_field_standard_settings', array( __CLASS__, 'add_field_settings' ), 10, 2 );
+add_action( 'gform_editor_js_set_default_values', array( __CLASS__, 'set_default_properties' ) );
+}
+
+/**
+ * Get the field title used in the editor.
+ *
+ * @return string
+ */
+public function get_form_editor_field_title() {
+return esc_html__( 'Visual Product Configurator', 'gf-visual-product-configurator' );
+}
+
+/**
+ * Return field description for the editor panel.
+ *
+ * @return string
+ */
+public function get_form_editor_field_description() {
+return esc_html__( 'Display a live, layered product preview and capture the final configuration as an image.', 'gf-visual-product-configurator' );
+}
+
+/**
+ * Specify which field settings to display in the form editor for this field type.
+ *
+ * @return array
+ */
+public function get_form_editor_field_settings() {
+return array(
+'label_setting',
+'admin_label_setting',
+'size_setting',
+'visibility_setting',
+'css_class_setting',
+'visual_configurator_setting',
+);
+}
+
+/**
+ * Visual Configurator field does not support conditional logic as a target.
+ *
+ * @return bool
+ */
+public function is_conditional_logic_supported() {
+return false;
+}
+
+/**
+ * Render the field input markup on the front end.
+ *
+ * @param array       $form  Form object.
+ * @param string      $value Current value.
+ * @param null|array  $entry Entry object.
+ * @param string      $form_id  Form ID.
+ * @param string      $field_id Field ID.
+ * @param string|null $html_id HTML ID attribute.
+ * @param string|null $css_class CSS class attribute.
+ *
+ * @return string
+ */
+public function get_field_input( $form, $value = '', $entry = null ) {
+$form_id  = isset( $form['id'] ) ? absint( $form['id'] ) : 0;
+$field_id = absint( $this->id );
+$html_id  = $this->get_input_id( $form_id );
+$name     = sprintf( 'input_%d', $field_id );
+
+$config      = $this->get_config_settings();
+$config_json = wp_json_encode( $config );
+$canvas      = isset( $config['canvas'] ) ? $config['canvas'] : array();
+$width       = isset( $canvas['width'] ) ? absint( $canvas['width'] ) : 600;
+$height      = isset( $canvas['height'] ) ? absint( $canvas['height'] ) : 600;
+
+$hidden_input = sprintf(
+'<input type="hidden" name="%1$s" id="%2$s" value="%3$s" class="gf-vpc-result" />',
+esc_attr( $name ),
+esc_attr( $html_id ),
+esc_attr( $value )
+);
+
+$canvas_markup = sprintf(
+'<canvas class="gf-vpc-canvas" width="%1$d" height="%2$d"></canvas>',
+$width,
+$height
+);
+
+$container_markup = sprintf(
+'<div class="gf-visual-configurator" data-field-id="%1$d" data-form-id="%2$d" data-config="%3$s">%4$s<div class="gf-vpc-control-container"></div>%5$s</div>',
+$field_id,
+$form_id,
+esc_attr( $config_json ),
+$canvas_markup,
+$hidden_input
+);
+
+return sprintf( '<div class="gf-visual-configurator-field">%s</div>', $container_markup );
+}
+
+/**
+ * Format entry value for the entry detail view.
+ *
+ * @param string $value Entry value.
+ * @param string $currency Currency.
+ * @param bool   $use_text Use text.
+ * @param string $format Format.
+ * @param string $media Media.
+ *
+ * @return string
+ */
+public function get_value_entry_detail( $value, $currency = '', $use_text = false, $format = 'html', $media = 'screen' ) {
+if ( empty( $value ) ) {
+return ''; // Nothing to display.
+}
+
+if ( 'text' === $format ) {
+return $value;
+}
+
+return sprintf( '<img class="gf-vpc-entry-image" src="%s" alt="%s" />', esc_attr( $value ), esc_attr__( 'Configured product preview', 'gf-visual-product-configurator' ) );
+}
+
+/**
+ * Add field button in the editor.
+ *
+ * @param array $field_groups Field button groups.
+ *
+ * @return array
+ */
+public static function add_form_editor_button( $field_groups ) {
+foreach ( $field_groups as &$group ) {
+if ( 'advanced_fields' === $group['name'] ) {
+$group['fields'][] = array(
+'class'     => 'button',
+'value'     => esc_html__( 'Visual Configurator', 'gf-visual-product-configurator' ),
+'data-type' => 'visual_configurator',
+);
+break;
+}
+}
+
+return $field_groups;
+}
+
+/**
+ * Register Gravity Forms tooltips.
+ *
+ * @param array $tooltips Existing tooltips.
+ *
+ * @return array
+ */
+public static function register_tooltips( $tooltips ) {
+$tooltips['visual_configurator_canvas'] = sprintf( '<h6>%1$s</h6><p>%2$s</p>', esc_html__( 'Canvas Settings', 'gf-visual-product-configurator' ), esc_html__( 'Define the dimensions and base product image shown beneath all layers.', 'gf-visual-product-configurator' ) );
+$tooltips['visual_configurator_layers'] = sprintf( '<h6>%1$s</h6><p>%2$s</p>', esc_html__( 'Layer Stack', 'gf-visual-product-configurator' ), esc_html__( 'Configure each layer, choose the controlling field, and map values to colors or images.', 'gf-visual-product-configurator' ) );
+
+return $tooltips;
+}
+
+/**
+ * Output the field settings panel in the editor.
+ *
+ * @param int $position Current position index.
+ * @param int $form_id  Form ID.
+ */
+public static function add_field_settings( $position, $form_id ) {
+if ( 50 !== $position ) {
+return;
+}
+?>
+<li class="visual_configurator_setting field_setting" style="display:none;">
+<input type="hidden" id="visual_configurator_settings" />
+<div class="gf-vpc-setting-section" data-gf-tooltip="visual_configurator_canvas">
+<h4><?php esc_html_e( 'Preview Canvas', 'gf-visual-product-configurator' ); ?></h4>
+<div class="gf-vpc-field-grid">
+<label for="gf-vpc-canvas-width"><?php esc_html_e( 'Width (px)', 'gf-visual-product-configurator' ); ?></label>
+<input type="number" id="gf-vpc-canvas-width" class="small" min="1" step="1" />
+
+<label for="gf-vpc-canvas-height"><?php esc_html_e( 'Height (px)', 'gf-visual-product-configurator' ); ?></label>
+<input type="number" id="gf-vpc-canvas-height" class="small" min="1" step="1" />
+
+<label for="gf-vpc-base-image"><?php esc_html_e( 'Base Image', 'gf-visual-product-configurator' ); ?></label>
+<div class="gf-vpc-media-control">
+<input type="text" id="gf-vpc-base-image" readonly />
+<button type="button" class="button gf-vpc-select-media" data-target="baseImage"><?php esc_html_e( 'Select Image', 'gf-visual-product-configurator' ); ?></button>
+<button type="button" class="button-link gf-vpc-clear-media" data-target="baseImage"><?php esc_html_e( 'Clear', 'gf-visual-product-configurator' ); ?></button>
+</div>
+</div>
+</div>
+
+<div class="gf-vpc-setting-section" data-gf-tooltip="visual_configurator_layers">
+<h4><?php esc_html_e( 'Layer Stack', 'gf-visual-product-configurator' ); ?></h4>
+<p class="description"><?php esc_html_e( 'Create, sort, and configure the layers that will be rendered on the preview canvas.', 'gf-visual-product-configurator' ); ?></p>
+<ul class="gf-vpc-layers" aria-live="polite"></ul>
+<button type="button" class="button gf-vpc-add-layer"><?php esc_html_e( 'Add Layer', 'gf-visual-product-configurator' ); ?></button>
+</div>
+
+<template id="gf-vpc-layer-template">
+<li class="gf-vpc-layer" data-layer-index="">
+<div class="gf-vpc-layer-header">
+<span class="gf-vpc-layer-title"></span>
+<div class="gf-vpc-layer-actions">
+<button type="button" class="button-link gf-vpc-remove-layer"><?php esc_html_e( 'Remove', 'gf-visual-product-configurator' ); ?></button>
+<span class="dashicons dashicons-move" aria-hidden="true"></span>
+</div>
+</div>
+<div class="gf-vpc-layer-body">
+<label>
+<span><?php esc_html_e( 'Layer Name', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-name" />
+</label>
+
+<label>
+<span><?php esc_html_e( 'Layer Type', 'gf-visual-product-configurator' ); ?></span>
+<select class="gf-vpc-layer-type">
+<option value="color_fill"><?php esc_html_e( 'Color Fill', 'gf-visual-product-configurator' ); ?></option>
+<option value="image_upload"><?php esc_html_e( 'Image (from Upload)', 'gf-visual-product-configurator' ); ?></option>
+<option value="image_choice"><?php esc_html_e( 'Image (from Choice)', 'gf-visual-product-configurator' ); ?></option>
+<option value="image_overlay"><?php esc_html_e( 'Image Overlay', 'gf-visual-product-configurator' ); ?></option>
+</select>
+</label>
+
+<label>
+<span><?php esc_html_e( 'Control Field ID', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-control" placeholder="e.g. 5" />
+</label>
+
+<fieldset class="gf-vpc-layer-position">
+<legend><?php esc_html_e( 'Position &amp; Size (%)', 'gf-visual-product-configurator' ); ?></legend>
+<label>
+<span><?php esc_html_e( 'X', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-pos" data-axis="x" placeholder="0" />
+</label>
+<label>
+<span><?php esc_html_e( 'Y', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-pos" data-axis="y" placeholder="0" />
+</label>
+<label>
+<span><?php esc_html_e( 'Width', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-pos" data-axis="width" placeholder="100" />
+</label>
+<label>
+<span><?php esc_html_e( 'Height', 'gf-visual-product-configurator' ); ?></span>
+<input type="text" class="gf-vpc-layer-pos" data-axis="height" placeholder="100" />
+</label>
+</fieldset>
+
+<label class="gf-vpc-layer-conditional">
+<input type="checkbox" class="gf-vpc-layer-conditional-toggle" />
+<span><?php esc_html_e( 'Enable Conditional Logic for this Layer', 'gf-visual-product-configurator' ); ?></span>
+</label>
+
+<div class="gf-vpc-layer-media gf-vpc-layer-overlay">
+<label>
+<span><?php esc_html_e( 'Overlay Image', 'gf-visual-product-configurator' ); ?></span>
+<div class="gf-vpc-media-control">
+<input type="text" class="gf-vpc-layer-overlay-url" readonly />
+<button type="button" class="button gf-vpc-select-media" data-target="overlayImage"><?php esc_html_e( 'Select Image', 'gf-visual-product-configurator' ); ?></button>
+<button type="button" class="button-link gf-vpc-clear-media" data-target="overlayImage"><?php esc_html_e( 'Clear', 'gf-visual-product-configurator' ); ?></button>
+</div>
+</label>
+</div>
+
+<div class="gf-vpc-layer-choice-mapping">
+<h5><?php esc_html_e( 'Image Choice Mapping', 'gf-visual-product-configurator' ); ?></h5>
+<ul class="gf-vpc-choice-list"></ul>
+<button type="button" class="button gf-vpc-add-choice"><?php esc_html_e( 'Add Choice Image', 'gf-visual-product-configurator' ); ?></button>
+</div>
+</div>
+</li>
+</template>
+
+<template id="gf-vpc-choice-template">
+<li class="gf-vpc-choice" data-choice-index="">
+<div class="gf-vpc-choice-fields">
+<input type="text" class="gf-vpc-choice-value" placeholder="<?php esc_attr_e( 'Choice value (e.g. Red)', 'gf-visual-product-configurator' ); ?>" />
+<div class="gf-vpc-media-control">
+<input type="text" class="gf-vpc-choice-image" readonly />
+<button type="button" class="button gf-vpc-select-media" data-target="choiceImage"><?php esc_html_e( 'Select Image', 'gf-visual-product-configurator' ); ?></button>
+<button type="button" class="button-link gf-vpc-remove-choice"><?php esc_html_e( 'Remove', 'gf-visual-product-configurator' ); ?></button>
+</div>
+</div>
+</li>
+</template>
+</li>
+<?php
+}
+
+/**
+ * Ensure the field has default properties when added to a form.
+ */
+public static function set_default_properties() {
+?>
+case 'visual_configurator':
+field.label = <?php echo wp_json_encode( esc_html__( 'Visual Product Configurator', 'gf-visual-product-configurator' ) ); ?>;
+field.visual_configurator_settings = <?php echo wp_json_encode( self::get_default_settings() ); ?>;
+break;
+<?php
+}
+
+/**
+ * Retrieve default configuration settings.
+ *
+ * @return array
+ */
+public static function get_default_settings() {
+return array(
+'canvas' => array(
+'width'     => 600,
+'height'    => 600,
+'baseImage' => array(
+'id'  => 0,
+'url' => '',
+),
+),
+'layers' => array(),
+);
+}
+
+/**
+ * Get the stored configuration settings for this field.
+ *
+ * @return array
+ */
+protected function get_config_settings() {
+$settings = isset( $this->visual_configurator_settings ) ? $this->visual_configurator_settings : array();
+
+if ( empty( $settings ) || ! is_array( $settings ) ) {
+$settings = self::get_default_settings();
+}
+
+return $settings;
+}
+}
+}


### PR DESCRIPTION
## Summary
- scaffold a Gravity Forms addon plugin that registers a Visual Product Configurator field type and conditionally loads assets
- implement the field editor UI for configuring canvas settings, layered stack options, and media mappings
- build frontend logic to render the live canvas preview, react to field changes, and capture the composed image on submit

## Testing
- not run (WordPress plugin)

------
https://chatgpt.com/codex/tasks/task_e_68cc65a5e0e8832689395cf28bb03d0b